### PR TITLE
revert back 'filename' in GifJson.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -61,8 +61,7 @@ help_above = [
 poke_help="azrod\nbane\nrun\nsergei\n" #see comment in line 509
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-# gifs_file = os.path.join(dir_path, "utils/gifs.json")
-my_giflist = GifJson()
+my_giflist = GifJson("gifs.json")
 
 
 @bot.event

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -51,13 +51,13 @@ class TestDiscordBot(unittest.TestCase):
 
     def test_get_gif(self):
         """Test get_gif."""
-        gifs = GifJson("utils/gifs.sample.json")
+        gifs = GifJson("gifs.sample.json")
         my_gif = gifs.get_gif("your_gif_name")
         self.assertEqual(my_gif['url'], "your_gif_url")
 
     def test_get_gif_fail(self):
         """Test get_gif fail."""
-        gifs = GifJson("utils/gifs.sample.json")
+        gifs = GifJson("gifs.sample.json")
         my_gif = gifs.get_gif("toto")
         self.assertIsNone(my_gif)  # gif toto return none
 

--- a/utils/gif_json.py
+++ b/utils/gif_json.py
@@ -7,14 +7,14 @@ class GifJson:
     """Class to handle reading gifs url from json file."""
 
     # init is executed when the object is created
-    def __init__(self):
+    def __init__(self, filename):
         """Init object.
 
         Read (or create) json file.
         """
         dir_path = os.path.dirname(os.path.realpath(__file__))
 
-        self.file = os.path.join(dir_path, "gifs.json")
+        self.file = os.path.join(dir_path, filename)
         # if file exists
         try:
             f = open(self.file)


### PR DESCRIPTION
So that bot can use "gifs.json" and unittests can use "gifs.sample.json"