### PR TITLE
Fix + unittests for log + FIX

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python3
+# -*-coding:utf-8 -*-
+"""Unit tests."""
+
+
+import unittest
+from utils.logs import CommandLog
+
+
+class TestLog(unittest.TestCase):
+    """Run unit tests."""
+
+    # Each method with name beginning with 'test_'
+    # is a test.
+
+    def test_log_read_0(self):  # case 0, [None, None, None]
+        """Test log read."""
+        date = "08/11/2019"
+        arg_list = [None, None, None]
+        logs = CommandLog("logs.sample.json")
+        res = logs.log_read(date, *arg_list)
+        # print(res)
+        self.assertEqual(len(res), 5)
+
+    def test_log_read_1(self):  # case 1, [None, None, channel]
+        """Test log read."""
+        date = "08/11/2019"
+        arg_list = [None, None, "faq"]
+        logs = CommandLog("logs.sample.json")
+        res = logs.log_read(date, *arg_list)
+        # print(res)
+        ref = ('23h07m12s', 'bart', 'kick')
+        self.assertEqual(res[0], ref)
+
+    def test_log_read_2(self):  # case 2, [None, command, None]
+        """Test log read."""
+        date = "08/11/2019"
+        arg_list = [None, "clear", None]
+        logs = CommandLog("logs.sample.json")
+        res = logs.log_read(date, *arg_list)
+        # print(res)
+        self.assertEqual(len(res), 3)
+
+    def test_log_read_3(self):  # case 0, [None, command, channel]
+        """Test log read."""
+        date = "08/11/2019"
+        arg_list = [None, "clear", "general"]
+        logs = CommandLog("logs.sample.json")
+        res = logs.log_read(date, *arg_list)
+        # print(res)
+        ref = ('23h07m21s', 'lisa', 'clear')
+        self.assertEqual(res[1], ref)
+
+    def test_log_read_4(self):  # case 4, [user, None, None]
+        """Test log read."""
+        date = "08/11/2019"
+        arg_list = ["homer", None, None]
+        logs = CommandLog("logs.sample.json")
+        res = logs.log_read(date, *arg_list)
+        # print(res)
+        self.assertEqual(len(res), 2)
+
+    def test_log_read_5(self):  # case 5, [user, None, channel]
+        """Test log read."""
+        date = "08/11/2019"
+        arg_list = ["lisa", None, "faq"]
+        logs = CommandLog("logs.sample.json")
+        res = logs.log_read(date, *arg_list)
+        # print(res)
+        ref = ('23h07m25s', 'lisa', 'clear')
+        self.assertEqual(res[0], ref)
+
+    def test_log_read_6(self):  # case 6, [user, command, None]
+        """Test log read."""
+        date = "08/11/2019"
+        arg_list = ["homer", "ban", None]
+        logs = CommandLog("logs.sample.json")
+        res = logs.log_read(date, *arg_list)
+        # print(res)
+        ref = ('23h07m32s', 'homer', 'general')
+        self.assertEqual(res[0], ref)
+
+    def test_log_read_7(self):  # case 7, [user, command, channel]
+        """Test log read."""
+        date = "08/11/2019"
+        arg_list = ["bart", "kick", "faq"]
+        logs = CommandLog("logs.sample.json")
+        res = logs.log_read(date, *arg_list)
+        # print(res)
+        ref = ('08/11/2019', '23h07m12s')
+        self.assertEqual(res[0], ref)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/logs.py
+++ b/utils/logs.py
@@ -78,8 +78,8 @@ class CommandLog:
 
     def _get_date_time(self, user, command, channel):
         try:
-            return [(k, time) for k, v in self.logs.items()for time in v.keys()
-                    if {'channel': channel, 'user': user, 'command': command} in v.values()]  # noqa:E501
+            return [(k, time) for k, v in self.logs.items() for time in v.keys()  # noqa:E501
+                    if v[time] == {'channel': channel, 'user': user, 'command': command}]  # noqa:E501
         except KeyError:
             return None
 

--- a/utils/logs.sample.json
+++ b/utils/logs.sample.json
@@ -1,10 +1,29 @@
 {
-    "date": {
-        "time": {
-            "channel" : "channel",
-            "command" : "command",
-            "user" : "user"
+    "08/11/2019": {
+        "22h35m37s": {
+            "channel": "general",
+            "command": "clear",
+            "user": "homer"
+        },
+        "23h07m12s": {
+            "channel": "faq",
+            "command": "kick",
+            "user": "bart"
+        },
+        "23h07m21s": {
+            "channel": "general",
+            "command": "clear",
+            "user": "lisa"
+        },
+        "23h07m25s": {
+            "channel": "faq",
+            "command": "clear",
+            "user": "lisa"
+        },
+        "23h07m32s": {
+            "channel": "general",
+            "command": "ban",
+            "user": "homer"
         }
     }
-
 }


### PR DESCRIPTION
Des tests unitaires pour log_read

En gros, je teste les 8 cas, et j'essaye de valider (du coup j'ai mis les données de test dans le log.sample.json)
J'aurai pu faire un autre fichier, mais bon, je vois pas l'intérêt de rajouter un autre fichier alors que le sample peut servir à ça.
Mais c'est comme tu le sens.

Et du coup, en faisant les tests unitaires, je me suis rendu compte que le cas n==7 (celui où tout est spécifié, user, command et channl), ça ne rendait pas la chose attendue.

Du coup, j'ai proposé un fix également, dans le même commit.

See yah