### PR TITLE
Bot logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ example.py
 logs.json
 errors.log
 info.log
+modo.log

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ gifs.txt
 gifs.json
 example.py
 logs.json
+errors.log
+info.log

--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@
 """Awesome Discord Bot."""
 
 import asyncio
+import logging
 import sys
 import random
 
@@ -11,6 +12,7 @@ from discord.ext import commands
 
 import cogs
 
+from utils.bot_logging import setup_logging
 from utils.constants import greeting_list
 from utils.logs import CommandLog
 from utils.gif_json import GifJson
@@ -78,4 +80,15 @@ async def on_ready():
     # TODO : doctring
     # await ctx.send(content=reddit_nsfw())
 
-bot.run(token)
+setup_logging()
+logger = logging.getLogger(__name__)
+
+logger.info("This is an INFO message on the root logger.")
+# logger.warning("This is a WARNING message of the root logger")
+# logger.error("This is a ERROR message of the root logger")
+# logger.critical("This is a CRITICAL message of the root logger")
+
+try:
+    bot.run(token)
+except Exception:
+    logger.critical("Unexpected critical error", exc_info=True)

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import logging
 import random
 
 import discord
@@ -12,6 +13,8 @@ from discord.ext import commands
 dctradlogo = "http://www.dctrad.fr/ext/planetstyles/flightdeck/store/logodctweb.png"  # noqa: E501
 dctrad_recru = "http://www.dctrad.fr/viewforum.php?f=21"
 snap_url = "https://media.tenor.com/images/8d7d2e757f934793bb4154cede8a4afa/tenor.gif"  # noqa: E501
+
+logger = logging.getLogger(__name__)
 
 
 class Misc(commands.Cog):
@@ -58,6 +61,7 @@ class Misc(commands.Cog):
     async def ping(self, ctx):
         """Ping the bot."""
         await ctx.send(content="pong !")
+        logger.info(f"Ping (asked by {ctx.author}) was awaited.")
 
     @commands.command()
     async def roulette(self, ctx):

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -1,20 +1,23 @@
 import datetime
+import logging
 
-import discord
 from discord.ext import commands
 
 from utils.secret import mods_role
-from utils.logs import CommandLog
+# from utils.logs import CommandLog
+
+
+logger = logging.getLogger(__name__)
+
 
 class Mod(commands.Cog):
-    def __init__(self,bot):
+    def __init__(self, bot):
         self.bot = bot
         self.log = bot.log
-    
 
     @commands.command()
     @commands.has_any_role(*mods_role)
-    async def kick(self,ctx):
+    async def kick(self, ctx):
         """Kick user."""
         member_list = ctx.message.mentions
         for member in member_list:
@@ -22,21 +25,19 @@ class Mod(commands.Cog):
         today = datetime.date.today().strftime("%d/%m/%Y")
         time = datetime.datetime.now().strftime("%Hh%Mm%Ss")
         self.log.log_write(today, time,
-                    ctx.channel.name.lower(),
-                    ctx.command.name.lower(),
-                    ctx.author.name.lower())
+                           ctx.channel.name.lower(),
+                           ctx.command.name.lower(),
+                           ctx.author.name.lower())
         await ctx.send(content="Adios muchachos !")
 
-
     @kick.error
-    async def kick_error(self,ctx, error):
+    async def kick_error(self, ctx, error):
         """Handle error in !kick command (MissingAnyRole)."""
         await ctx.send(content=f"Tu n'as pas de pouvoirs{ctx.author.mention} !")  # noqa: E501
 
-
     @commands.command()
     @commands.has_any_role(*mods_role)
-    async def ban(self,ctx):
+    async def ban(self, ctx):
         """Ban user."""
         member_list = ctx.message.mentions
         for member in member_list:
@@ -44,18 +45,26 @@ class Mod(commands.Cog):
         today = datetime.date.today().strftime("%d/%m/%Y")
         time = datetime.datetime.now().strftime("%Hh%Mm%Ss")
         self.log.log_write(today, time,
-                    ctx.channel.name.lower(),
-                    ctx.command.name.lower(),
-                    ctx.author.name.lower())
-
+                           ctx.channel.name.lower(),
+                           ctx.command.name.lower(),
+                           ctx.author.name.lower())
 
     @ban.error
-    async def ban_error(self,ctx, error):
+    async def ban_error(self, ctx, error):
         """Handle error in !ban command (MissingAnyRole)."""
         await ctx.send(content=f"Tu n'as pas de pouvoirs{ctx.author.mention} !")  # noqa: E501
 
     @commands.command()
     @commands.has_any_role(*mods_role)
-    async def nomorespoil(self,ctx):
+    async def nomorespoil(self, ctx):
         """Spam dots to clear potential spoils."""
         await ctx.send("\n".join(["..." for i in range(50)]))
+
+    @commands.Cog.listener()
+    async def on_command(self, ctx):
+        # If test if not very fancy
+        # (no @decorator of special event on_cog_command for this ??)
+        # But otherwise, on_command() triggers on ALL commands (including ogher cogs)  # noqa: E501
+        # So we test if we're in current cog (self)
+        if ctx.command.cog_name == self.qualified_name:
+            logger.info(f"Command {str(ctx.command):15} invoked by {str(ctx.author):15} in room {str(ctx.channel):15} with message {ctx.message.content}")  # noqa: E501

--- a/cogs/youtube.py
+++ b/cogs/youtube.py
@@ -37,7 +37,8 @@ def search_youtube(user_input, number):
     DEVELOPER_KEY = token_youtube
 
     youtube = googleapiclient.discovery.build(
-        api_service_name, api_version, developerKey=DEVELOPER_KEY)
+        api_service_name, api_version, developerKey=DEVELOPER_KEY,
+        cache_discovery=False)
 
     request = youtube.search().list(  # pylint: disable=no-member
         part="snippet",

--- a/logging.json
+++ b/logging.json
@@ -1,0 +1,48 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+      "simple": {
+        "format": "%(asctime)s Bot: | %(name)33s | %(levelname)8s | %(message)s"
+      },
+      "other": {
+        "format": "%(asctime)s | %(name)10s | %(levelname)8s | %(message)s"
+      }
+    },
+  
+    "handlers": {
+      "console": {
+        "class": "logging.StreamHandler",
+        "level": "WARNING",
+        "formatter": "simple",
+        "stream": "ext://sys.stdout"
+      },
+  
+      "info_file_handler": {
+        "class": "logging.handlers.RotatingFileHandler",
+        "level": "INFO",
+        "formatter": "simple",
+        "filename": "info.log",
+        "maxBytes": 102400,
+        "backupCount": 2,
+        "encoding": "utf8"
+      },
+  
+      "error_file_handler": {
+        "class": "logging.handlers.RotatingFileHandler",
+        "level": "ERROR",
+        "formatter": "simple",
+        "filename": "errors.log",
+        "maxBytes": 102400,
+        "backupCount": 2,
+        "encoding": "utf8"
+      }
+    },
+  
+    "loggers": {},
+  
+    "root": {
+      "level": "INFO",
+      "handlers": ["console", "info_file_handler", "error_file_handler"]
+    }
+}

--- a/logging.json
+++ b/logging.json
@@ -36,10 +36,26 @@
         "maxBytes": 102400,
         "backupCount": 2,
         "encoding": "utf8"
+      },
+
+      "modo_file_handler": {
+        "class": "logging.handlers.RotatingFileHandler",
+        "level": "INFO",
+        "formatter": "other",
+        "filename": "modo.log",
+        "maxBytes": 102400,
+        "backupCount": 2,
+        "encoding": "utf8"
       }
     },
   
-    "loggers": {},
+    "loggers": {
+      "cogs.mod": {
+        "level": "INFO",
+        "handlers": ["modo_file_handler"],
+        "propagate": false
+      }
+    },
   
     "root": {
       "level": "INFO",

--- a/utils/bot_logging.py
+++ b/utils/bot_logging.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+"""Logging configuration."""
+
+import os
+import json
+import logging
+import logging.config
+
+
+def setup_logging(
+    default_path='logging.json',
+    default_level=logging.INFO,
+    env_key='LOG_CFG'
+):
+    """Setup logging configuration
+
+    """
+    path = default_path
+    if os.path.exists(path):
+        with open(path, 'rt') as f:
+            config = json.load(f)
+        logging.config.dictConfig(config)
+    else:
+        logging.basicConfig(level=default_level)


### PR DESCRIPTION
OK, on y est.

Donc :

Préambule.
Le module de logging utilise des "niveaux" de messages.
Qui sont dans l'ordre : DEBUG, INFO, WARNING, ERROR, CRITICAL.

Donc en écrivant le code, on peut très bien lancer des INFOS ou des ERROR et des DEBUG (par exemple pour observer l'état des variables dans une boucle) dans le log.
Ensuite, il suffit soit d'ajuster le niveau général du logging souhaité (si c'est INFO, bah tous les machins DEBUG ne seront pas loggés), etc...
Et de définir comment on veut logger ça.

Donc, pour notre code :

On va configurer notre module logging avec un fichier json (json -> dictionnaire)
https://github.com/Azrood/DCTbot/blob/edfa66498d1ad7c6ecaba709d40857939a7b9cfa/utils/bot_logging.py#L23
C'est pas obligatoire, tu peux le configurer dans le code.
Mais c'est pas génial, in-code. En json, tu peux changer ce que tu veux (changer le niveau de logging de INFO à WARNING, ou changer la sortie pour un autre fichier, ou même envoyer par mail, etc...). Sans toucher au code (ie, entre le développeur, qui va mettre son logging en mode DEBUG, et la production, avec un logging différent (envoyer les alertes critiques par mail à l'admin, etc...), pas besoin de toucher au code, tout se fait dans 1 seul fichier JSON...).

Donc ensuite :
On a des "**formaters**" :
`"format": "%(asctime)s Bot: | %(name)33s | %(levelname)8s | %(message)s"`

Pour spécifier comment on veut notre ligne de log.
J'en ai fait 2. simple, et other.

Ensuite, on a des **handlers**, à qui j'ai donné les **formaters** précédemment définis.
C'est ce qui va définir une "sortie" pour nos logs. Ça peut être un fichier avec FileHandler, envoyer un mail avec SMTPHandler, etc...

J'en ai fait 4 :
- la console (le terminal quoi, la sortie standard) et 4 fichiers.
- Un fichier info.log, qui contiendra tous les logs > INFO (donc INFO, WARNING, ERROR, CRITICAL)
- Un fichier error.log qui contiendra tous les logs > ERROR (ERROR et CRITICAL donc)
- Un fichier modo, dont je parlerai plus tard.

Une fois que j'ai fait ça, je configure mon logger par défault : **root**, qui aura les handlers console, info et error.
- un message INFO n'ira que dans info.log
- un message WARNING ira dans info.log (car WARNING > INFO) ET dans la console (level WARNING)
- un message ERROR ira dans la console et les 2 fichiers
- etc...

Donc on configure notre logging dans notre fichier principal.
https://github.com/Azrood/DCTbot/blob/edfa66498d1ad7c6ecaba709d40857939a7b9cfa/bot.py#L83
On instancie un logger (qui utilisera notre logger par défault : **root**)
https://github.com/Azrood/DCTbot/blob/edfa66498d1ad7c6ecaba709d40857939a7b9cfa/bot.py#L84
On peut tester avec le niveau INFO :
https://github.com/Azrood/DCTbot/blob/edfa66498d1ad7c6ecaba709d40857939a7b9cfa/bot.py#L86

Mais ce qui est cool, c'est qu'on a pas besoin de spécifier ça dans chaque fichier, avec le formater et le handler, etc...

Exemple dans le cog Misc :
On instancie un logger (et logging va automatiquement lui donner la configuration "root", ici).
Y a RIEN d'autre à faire.
https://github.com/Azrood/DCTbot/blob/edfa66498d1ad7c6ecaba709d40857939a7b9cfa/cogs/misc.py#L17
Ensuite, j'ai décidé de logger quelque chose dans la commande !ping :
https://github.com/Azrood/DCTbot/blob/edfa66498d1ad7c6ecaba709d40857939a7b9cfa/cogs/misc.py#L64

Dans mon fichier de log, avec le formater qu'on a donné, ça donne :
`2020-01-23 11:09:30,626 Bot: |                         cogs.misc |     INFO | Ping (asked by Sergei#8175) was awaited.`

C'est tout. Donc on peut faire ça où on veut, dorénavant. Y a rien à faire.
Et encore plus fort, cette configuration est passée aux modules qu'on importe, genre discord.py ou les trucs de Google pour Youtube, etc... Tout est automatique.

On peut logger facilement directement avec le bon niveau, grâce à des fonctions :
```python
logger.info("This is an INFO message on the root logger.")
logger.warning("This is a WARNING message of the root logger")
logger.error("This is a ERROR message of the root logger")
logger.critical("This is a CRITICAL message of the root logger")
```

Et dans la config, j'ai défini un autre logger, pour le cog de modération.
Pour écrire dans un fichier spécifique, avec un formatage spécifique.

Donc comme d'habitude, on fait :
https://github.com/Azrood/DCTbot/blob/edfa66498d1ad7c6ecaba709d40857939a7b9cfa/cogs/mod.py#L10
Sauf qu'ici, `__name__` va être `cogs.mod`, et donc au lieu d'instancier un logger de type "root", il va instancier mon logger spécial (cogs.mod).
Rien de spécial à dire, c'est juste que ça va écrire dans un fichier différent (modo.log).

Enfin, au lieu d'écrire une ligne de log dans chaque commande, j'ai mis ça dans un event on_command
https://github.com/Azrood/DCTbot/blob/edfa66498d1ad7c6ecaba709d40857939a7b9cfa/cogs/mod.py#L64
(par contre, c'était trigger par toutes les commandes, même d'autres cogs, c'est pas super bien foutu, ou alors j'ai pas compris un truc de discord.py... Fin peu importe, j'ai ajouté un if, et ça fait le café).

Du coup, comme j'ai défini :
`"handlers": ["modo_file_handler"],`
bah ça n'écrit que dans le fichier modo.log
Mais je pourrai ajouter le hangler `info_file_handler` si je le voulais pour que ce fichier contienne vraiment tout. Fin on peut tout faire, en fait.

On pourrait aussi imaginer loger des choses, en définissant un machin `on_commend_error`, etc...

Voilà (c'est à la fois "en gros" et "en détail", mais bon...)

Là, c'est vraiment le machin assez complet.
Mais je te filerai un fichier avec le truc ultra basique (sans json, etc...) si tu veux.

See yah.

PS :
Exemples de fichiers de log (avec la version 1.2.4 de discord.py qui buggait sur les réactions emojis) :
On a bien le traceback (j'ai try/except le bot.run(), avec le log des erreurs dans le except)
[info_with_1.2.4.log](https://github.com/Azrood/DCTbot/files/4102453/info_with_1.2.4.log)
[errors_with_1.2.4.log](https://github.com/Azrood/DCTbot/files/4102455/errors_with_1.2.4.log)

Sinon, en version 1.2.5 (on voit bien le log de discord, de mon ping, et de l'api google) :
[info.log](https://github.com/Azrood/DCTbot/files/4102477/info.log)


